### PR TITLE
Optimize internlm2-chat-126m memory usage

### DIFF
--- a/accessory/model/LLM/internlm.py
+++ b/accessory/model/LLM/internlm.py
@@ -185,11 +185,11 @@ class FeedForward(nn.Module):
         self.w1 = ColumnParallelLinear(
             dim, hidden_dim, bias=bias, gather_output=False
         )
-        self.w2 = RowParallelLinear(
-            dim, hidden_dim, bias=bias, input_is_parallel=True
-        )
         self.w3 = ColumnParallelLinear(
-            hidden_dim, out_dim, bias=bias, gather_output=False
+            dim, hidden_dim, bias=bias, gather_output=False
+        )
+        self.w2 = RowParallelLinear(
+            hidden_dim, out_dim, bias=bias, input_is_parallel=True
         )
 
     # @torch.compile
@@ -197,7 +197,7 @@ class FeedForward(nn.Module):
         return F.silu(x) * y
 
     def forward(self, x):
-        return self.w3(self._silu_gating(self.w1(x), self.w2(x)))
+        return self.w2(self._silu_gating(self.w1(x), self.w3(x)))
 
 
 class PackedFlashBaseLayer1D(nn.Module):


### PR DESCRIPTION
Fixes tensor parallelism configuration in InternLM's FeedForward layer to resolve shape mismatch during training.

The previous setup of `ColumnParallelLinear` and `RowParallelLinear` in the `FeedForward` module led to incorrect input dimensions for matrix multiplication, specifically when `w3` received an input from `_silu_gating(w1(x), w2(x))`, causing a `RuntimeError: mat1 and mat2 shapes cannot be multiplied`. This PR reconfigures the layers (`w1`, `w2`, `w3`) and their usage in the forward pass to align with the correct tensor parallelism pattern for gated linear units, ensuring proper sharding and dimension matching.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f18e098-ed21-47f2-9c4c-ee83a92cf71d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f18e098-ed21-47f2-9c4c-ee83a92cf71d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

