### PR TITLE
Exclude embedding parameters from pretrain print

### DIFF
--- a/accessory/main_pretrain.py
+++ b/accessory/main_pretrain.py
@@ -166,7 +166,7 @@ def main(args):
                           args.tokenizer_path, with_visual=False,
                           max_seq_len=args.max_words)
     promote_trainable_params_to_fp32(model)
-    misc.print_param_status(model)
+    misc.print_param_status(model, exclude_embedding=True)
     if args.pretrained_path and fs_init.get_data_parallel_rank() == 0:
         print(f"load pretrained from {args.pretrained_path}")
         load_result = load_tensor_parallel_model_list(model, args.pretrained_path)

--- a/accessory/util/misc.py
+++ b/accessory/util/misc.py
@@ -596,14 +596,32 @@ def mark_mp_params(model: torch.nn.Module):
             m.weight.is_model_parallel = True
 
 
-def print_param_status(model: torch.nn.Module) -> None:
+def print_param_status(model: torch.nn.Module, exclude_embedding: bool = True) -> None:
     require_grad_set = []
     no_grad_set = []
+    embedding_params_count = 0
+    embedding_params_size = 0
+    
     for name, param in model.named_parameters():
+        # Check if this parameter belongs to an embedding layer
+        is_embedding = any(keyword in name.lower() for keyword in [
+            'embed', 'embedding', 'token_embedding', 'word_embedding', 
+            'tok_embeddings', 'word_embeddings', 'class_embedding', 
+            'positional_embedding'
+        ])
+        
+        if is_embedding and exclude_embedding:
+            embedding_params_count += 1
+            embedding_params_size += param.numel()
+            continue
+            
         if param.requires_grad:
             require_grad_set.append((name, param))
         else:
             no_grad_set.append((name, param))
+
+    if exclude_embedding and embedding_params_count > 0:
+        print(f"Excluded {embedding_params_count} embedding parameters ({embedding_params_size:,} total parameters)\n")
 
     print("Params that require gradient:\n")
     for name, param in require_grad_set:


### PR DESCRIPTION
Exclude embedding layer parameters from being printed during pretraining to improve log clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dca93a2-f820-41b9-8c2b-76a7471515c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5dca93a2-f820-41b9-8c2b-76a7471515c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

