### PR TITLE
Iterate and load pickled zstd objects

### DIFF
--- a/iter_pickle_zst.py
+++ b/iter_pickle_zst.py
@@ -1,0 +1,33 @@
+import zstandard as zstd
+import pickle
+import struct
+import io
+
+PATH = 'multi_tokens.zst'
+
+def iter_objects(path):
+    dctx = zstd.ZstdDecompressor()
+    with open(path, 'rb') as f:
+        while True:
+            len_bytes = f.read(4)
+            if len(len_bytes) < 4:
+                break
+            frame_size = struct.unpack('<I', len_bytes)[0]
+            print(f"frame_size is {frame_size}")
+            compressed = f.read(frame_size)
+
+            # ① 方案 A：直接解压（需给 max_output_size）
+            # pb = dctx.decompress(compressed, max_output_size=100_000_000)
+
+            # ② 方案 B：流式解压（推荐）
+            with dctx.stream_reader(io.BytesIO(compressed)) as reader:
+                pb = reader.read()
+            yield pickle.loads(pb)
+
+# ---------- 按需逐段读 ----------
+total_elems = 0
+for idx, chunk in enumerate(iter_objects(PATH)):
+    total_elems += len(chunk)
+    if idx % 10 == 0:
+        print(f'段 {idx} 元素累计:', total_elems)
+print('全部读完，总元素:', total_elems)


### PR DESCRIPTION
Add `iter_pickle_zst.py` to provide a utility for iterating through zstandard-compressed pickle objects.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dbf6331-d167-45f1-86ba-930e0cf1a7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9dbf6331-d167-45f1-86ba-930e0cf1a7a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

