### PR TITLE
Document tag centrality aggregation

### DIFF
--- a/analyze_tag_centrality.py
+++ b/analyze_tag_centrality.py
@@ -76,9 +76,76 @@ def analyze_centrality(co_occurrence_matrix_df, top_n=10):
 
     return results_df
 
+def calculate_document_centrality(doc_tags_map, tag_centrality_df, metric='Eigen_Score', method='mean'):
+    """
+    计算文档的中心性。
+    
+    思路:
+    用户提出的 "avg" (平均值) 是一个非常合理的基准方法。它反映了文档中包含的 Tag 的“平均重要程度”。
+    - 如果一个文档包含很少但很核心的 Tag，平均分会高。
+    - 如果一个文档包含很多边缘 Tag，平均分会低。
+    
+    此外，也可以考虑 'sum' (总和)，反映文档的信息量总量（中心 Tag 越多越好）。
+    
+    Args:
+        doc_tags_map (dict or pd.Series): 文档ID到Tag列表的映射 {doc_id: [tag1, tag2, ...]}
+        tag_centrality_df (pd.DataFrame): 包含Tag中心性分数的DataFrame，必须包含 'Tag' 列和 metric 列。
+        metric (str): 用于计算的中心性指标列名 (如 'Eigen_Score', 'Neighbor_Count', 'Total_Cooccurrences')
+        method (str): 聚合方法 'mean' (平均值), 'sum' (总和), 'max' (最大值)
+        
+    Returns:
+        pd.DataFrame: 包含文档ID和计算出的中心性分数的 DataFrame
+    """
+    print(f"\n正在计算文档中心度 (Metric: {metric}, Method: {method})...")
+    
+    # 创建 Tag 到 Score 的查找字典，提高效率
+    if 'Tag' not in tag_centrality_df.columns:
+        # 假设索引是 Tag
+        tag_score_map = tag_centrality_df[metric].to_dict()
+    else:
+        tag_score_map = dict(zip(tag_centrality_df['Tag'], tag_centrality_df[metric]))
+        
+    doc_scores = []
+    
+    # 统一将输入转换为 items 迭代器
+    iterator = doc_tags_map.items() if isinstance(doc_tags_map, dict) else doc_tags_map.items()
+    
+    for doc_id, tags in iterator:
+        if not tags:
+            doc_scores.append({'DocID': doc_id, 'Doc_Centrality': 0})
+            continue
+            
+        # 获取该文档所有 Tag 的分数，如果 Tag 不在分析结果中（可能是低频词被过滤了），默认给 0
+        scores = [tag_score_map.get(tag, 0) for tag in tags]
+        
+        if not scores:
+            final_score = 0
+        elif method == 'mean':
+            final_score = np.mean(scores)
+        elif method == 'sum':
+            final_score = np.sum(scores)
+        elif method == 'max':
+            final_score = np.max(scores)
+        else:
+            raise ValueError(f"Unknown method: {method}")
+            
+        doc_scores.append({
+            'DocID': doc_id,
+            'Doc_Centrality': final_score,
+            'Tag_Count': len(tags),
+            'Tags': str(tags) # 方便查看
+        })
+        
+    doc_scores_df = pd.DataFrame(doc_scores)
+    
+    # 排序
+    doc_scores_df = doc_scores_df.sort_values(by='Doc_Centrality', ascending=False)
+    
+    return doc_scores_df
+
 # --- 模拟数据示例 (你可以替换为加载真实数据的代码) ---
 if __name__ == "__main__":
-    # 模拟一个简单的共现矩阵
+    # 1. 模拟标签共现矩阵
     data = {
         'AI':           [5, 3, 1, 0, 4],
         'MachineLearning': [3, 6, 2, 0, 2],
@@ -93,4 +160,28 @@ if __name__ == "__main__":
     print(df_mock)
     print("-" * 30)
     
-    analyze_centrality(df_mock)
+    # 2. 计算 Tag 中心性
+    tag_centrality_df = analyze_centrality(df_mock)
+    
+    # 3. 模拟文档-标签数据
+    doc_tags = {
+        'doc_1': ['AI', 'MachineLearning', 'BigData'], # 都是核心词
+        'doc_2': ['Cooking'],                          # 边缘词
+        'doc_3': ['Python', 'Cooking'],                # 混合
+        'doc_4': ['AI', 'Python']                      # 核心+连接词
+    }
+    
+    print("\n模拟文档数据:")
+    for d, t in doc_tags.items():
+        print(f"{d}: {t}")
+        
+    # 4. 计算文档中心性 (使用平均值)
+    doc_centrality_df = calculate_document_centrality(
+        doc_tags, 
+        tag_centrality_df, 
+        metric='Eigen_Score', 
+        method='mean'
+    )
+    
+    print("\n=== 文档中心度排名 (Mean Eigen_Score) ===")
+    print(doc_centrality_df.to_string(index=False))


### PR DESCRIPTION
Add `calculate_document_centrality` function to compute document centrality by aggregating the centrality scores of its associated tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f42d260-08ae-4796-93c4-b0fec601187c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f42d260-08ae-4796-93c4-b0fec601187c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

