### PR TITLE
Add resume options for data-index reset and LR restart

### DIFF
--- a/accessory/engine_pretrain.py
+++ b/accessory/engine_pretrain.py
@@ -21,6 +21,50 @@ import torch.distributed as dist
 import multiprocessing as mp
 
 
+def _build_packed_reset_attention_mask(tokens: torch.Tensor, eod_token_id: int, pad_token_id: int = 0):
+    """
+    Build per-sample causal mask with document-boundary isolation.
+    Tokens from different EOS-separated segments cannot attend to each other.
+    """
+    bsz, seqlen = tokens.shape
+    causal = torch.tril(torch.ones((seqlen, seqlen), dtype=torch.bool, device=tokens.device))
+    attention_mask = torch.zeros((bsz, 1, seqlen, seqlen), dtype=torch.bool, device=tokens.device)
+
+    for b in range(bsz):
+        sample = tokens[b]
+        valid = sample.ne(pad_token_id)
+        eod = sample.eq(eod_token_id) & valid
+        # Keep EOS token in the preceding segment; reset starts after EOS.
+        seg = torch.cumsum(eod.to(torch.int64), dim=0)
+        seg = torch.roll(seg, shifts=1, dims=0)
+        seg[0] = 0
+        same_segment = seg.unsqueeze(0).eq(seg.unsqueeze(1))
+        valid_query = valid.unsqueeze(1)
+        valid_key = valid.unsqueeze(0)
+        attention_mask[b, 0] = causal & same_segment & valid_query & valid_key
+
+    return attention_mask
+
+
+def _prepare_training_masks(examples: torch.Tensor, labels: torch.Tensor, args):
+    labels_for_loss = labels
+    attention_mask = None
+    eod_token_id = getattr(args, "eod_token_id", None)
+
+    if getattr(args, "eod_mask_loss", False):
+        if eod_token_id is None:
+            raise RuntimeError("eod_mask_loss enabled but eod_token_id is unavailable")
+        labels_for_loss = labels.clone()
+        labels_for_loss[labels_for_loss == eod_token_id] = 0
+
+    if getattr(args, "reset_attention_mask", False):
+        if eod_token_id is None:
+            raise RuntimeError("reset_attention_mask enabled but eod_token_id is unavailable")
+        attention_mask = _build_packed_reset_attention_mask(examples, eod_token_id=eod_token_id, pad_token_id=0)
+
+    return labels_for_loss, attention_mask
+
+
 def _parse_iter_from_ckpt_dir(name: str):
     match = re.search(r"iter(\d+)", name)
     if match:
@@ -239,8 +283,9 @@ def train_one_epoch(model: torch.nn.Module,
             "fp16": torch.cuda.amp.autocast(dtype=torch.float16),
             "tf32": contextlib.nullcontext(),
         }[args.precision]
+        labels_for_loss, attention_mask = _prepare_training_masks(examples, labels, args)
         with autocast_ctx:
-             c_loss, additional_loss_dict = model(examples, labels)
+             c_loss, additional_loss_dict = model(examples, labels_for_loss, attention_mask=attention_mask)
         loss = c_loss
         for (add_loss, weight) in additional_loss_dict.values():
             loss = loss + add_loss * weight
@@ -370,8 +415,9 @@ def val_one_epoch(model: torch.nn.Module,
             "fp16": torch.cuda.amp.autocast(dtype=torch.float16),
             "tf32": contextlib.nullcontext(),
         }[args.precision]
+        labels_for_loss, attention_mask = _prepare_training_masks(examples, labels, args)
         with autocast_ctx:
-             c_loss, additional_loss_dict = model(examples, labels)
+             c_loss, additional_loss_dict = model(examples, labels_for_loss, attention_mask=attention_mask)
         c_loss_value = c_loss.item()
 
         metric_logger.update(closs=c_loss_value)
@@ -398,8 +444,9 @@ def val_one_epoch_local(model: torch.nn.Module,
             "fp16": torch.cuda.amp.autocast(dtype=torch.float16),
             "tf32": contextlib.nullcontext(),
         }[args.precision]
+        labels_for_loss, attention_mask = _prepare_training_masks(examples, labels, args)
         with autocast_ctx:
-            c_loss, additional_loss_dict = model(examples, labels)
+            c_loss, additional_loss_dict = model(examples, labels_for_loss, attention_mask=attention_mask)
         c_loss_value = c_loss.item()
         metric_logger.update(closs=c_loss_value)
     # DO NOT synchronize between processes here

--- a/accessory/engine_pretrain.py
+++ b/accessory/engine_pretrain.py
@@ -220,7 +220,9 @@ def train_one_epoch(model: torch.nn.Module,
     ):
 
         if data_iter_step % accum_iter == 0:
-            lr_sched.adjust_learning_rate(optimizer, data_iter_step, args)
+            lr_offset = getattr(args, "lr_resume_offset", 0)
+            lr_sched_step = max(data_iter_step - lr_offset, 0)
+            lr_sched.adjust_learning_rate(optimizer, lr_sched_step, args)
 
         # Update token counter
         batch_size, seq_len = examples.shape

--- a/accessory/main_pretrain.py
+++ b/accessory/main_pretrain.py
@@ -97,6 +97,10 @@ def get_args_parser():
                         help='root path for data')
     parser.add_argument('--packed_data', action="store_true",
                         help='use packed dataset')
+    parser.add_argument('--reset_attention_mask', action='store_true',
+                        help='for packed data, reset attention across EOS boundaries')
+    parser.add_argument('--eod_mask_loss', action='store_true',
+                        help='mask EOS token loss during training')
     parser.add_argument('--max_words', default=2048, type=int,
                         help='max token length')
 
@@ -254,6 +258,14 @@ def main(args):
     dataset_val = DatasetValCls(args.data_meta_path, args.data_root, tokenizer_path=args.tokenizer_path,
                                 max_words=args.max_words)
     print(dataset_train)
+    args.eod_token_id = dataset_train.tokenizer.eos_id
+    if args.reset_attention_mask and not args.packed_data:
+        warnings.warn("reset_attention_mask is usually intended for packed_data mode")
+    if args.reset_attention_mask or args.eod_mask_loss:
+        print(
+            f"mask config: reset_attention_mask={args.reset_attention_mask}, "
+            f"eod_mask_loss={args.eod_mask_loss}, eod_token_id={args.eod_token_id}"
+        )
 
     if global_rank == 0 and args.output_dir is not None:
         os.makedirs(args.output_dir, exist_ok=True)

--- a/accessory/main_pretrain.py
+++ b/accessory/main_pretrain.py
@@ -40,6 +40,7 @@ except ImportError:
     from torch.optim import AdamW
 
 import accessory.util.misc as misc
+import accessory.util.lr_sched as lr_sched
 from accessory.util.misc import NativeScalerWithGradNormCount as NativeScaler
 from accessory.util.tensor_type import default_tensor_type, promote_trainable_params_to_fp32
 from accessory.util.tensor_parallel import load_tensor_parallel_model_list
@@ -82,6 +83,9 @@ def get_args_parser():
                         help='iterations to warmup LR')
     parser.add_argument('--lr_decay_iters', type=int, default=1800000, metavar='N',
                         help='iters before keeping minimal learning rate')
+    parser.add_argument('--lr_schedule', type=str, default='cosine',
+                        choices=['cosine', 'constant'],
+                        help='learning rate schedule type')
 
     parser.add_argument('--clip_grad', type=int, default=-1,
                         help='grad clipping norm')
@@ -103,6 +107,10 @@ def get_args_parser():
     parser.add_argument('--seed', default=0, type=int)
     parser.add_argument('--resume', default='',
                         help='resume from checkpoint')
+    parser.add_argument('--resume_reset_data_idx', action='store_true',
+                        help='when resuming, ignore dataset state and restart data loading from the beginning')
+    parser.add_argument('--resume_reset_lr', action='store_true',
+                        help='when resuming, keep iteration/optimizer states but restart lr schedule from step 0')
 
     parser.add_argument('--num_workers', default=5, type=int)
     parser.add_argument('--pin_mem', action='store_true',
@@ -274,9 +282,14 @@ def main(args):
     )
 
     start_iter = 0
+    args.lr_resume_offset = 0
     if args.resume:
         _, start_iter = misc.resume_stage2(args=args, model=model, optimizer=optimizer,
                                            loss_scaler=loss_scaler, dataset_train=dataset_train)
+        if args.resume_reset_lr:
+            args.lr_resume_offset = start_iter
+            lr_sched.adjust_learning_rate(optimizer, 0, args)
+            print(f"resume_reset_lr enabled: keeping global iter={start_iter}, but lr schedule restarts from 0")
 
     print(f"Start training")
     start_time = time.time()

--- a/accessory/model/LLM/llama.py
+++ b/accessory/model/LLM/llama.py
@@ -370,7 +370,7 @@ class Transformer(nn.Module):
         return image_tokens
 
 
-    def forward(self, examples, image=None):
+    def forward(self, examples, image=None, attention_mask=None):
         self._destroy_kv_cache()  # training always disables kv cache
         _bsz, seqlen = examples.shape
         h = self.tok_embeddings(examples)
@@ -382,10 +382,17 @@ class Transformer(nn.Module):
             image_words = image_tokens.shape[1]
             h = torch.cat((image_tokens, h), dim=1)
             seqlen = h.shape[1]
+            if attention_mask is not None:
+                # text-only custom attention mask is not compatible with image-token prepend.
+                raise ValueError("attention_mask with image input is not supported")
 
         freqs_cis = self.freqs_cis[:seqlen]
+        if attention_mask is not None:
+            mask = attention_mask
+        else:
+            mask = "causal"
         for layer in self.layers:
-            h = layer(h, start_pos=0, freqs_cis=freqs_cis, mask="causal")
+            h = layer(h, start_pos=0, freqs_cis=freqs_cis, mask=mask)
         h = self.norm(h)
         output = self.output(h[:, image_words:, :])
         return output

--- a/accessory/model/meta.py
+++ b/accessory/model/meta.py
@@ -56,6 +56,12 @@ class MetaModel(nn.Module):
         print("Model Args:\n", model.args)
 
         self.llma = model
+        try:
+            self._llma_supports_attention_mask = (
+                "attention_mask" in inspect.signature(self.llma.forward).parameters
+            )
+        except (TypeError, ValueError):
+            self._llma_supports_attention_mask = False
 
         self.criterion = torch.nn.CrossEntropyLoss(ignore_index=0)
 
@@ -240,7 +246,15 @@ class MetaModel(nn.Module):
             examples = examples[:, :pos+1]
             labels = labels[:, :pos+1]
 
-        output = self.llma(examples, images, attention_mask=attention_mask)
+        if attention_mask is not None:
+            if not self._llma_supports_attention_mask:
+                raise RuntimeError(
+                    f"llama_type={self.llama_type} does not support attention_mask in Transformer.forward. "
+                    f"Please use a model variant that supports it (e.g. llama) or disable --reset_attention_mask."
+                )
+            output = self.llma(examples, images, attention_mask=attention_mask)
+        else:
+            output = self.llma(examples, images)
         if isinstance(output, tuple):
             output, additional_loss = output
         else:

--- a/accessory/model/meta.py
+++ b/accessory/model/meta.py
@@ -223,7 +223,7 @@ class MetaModel(nn.Module):
         for key, value in self.get_trainable_params().items():
             value.requires_grad = True
 
-    def forward(self, examples, labels, images=None):
+    def forward(self, examples, labels, images=None, attention_mask=None):
         with torch.no_grad():
             non_zero_ = torch.count_nonzero(labels, dim=0)
             pos = non_zero_.shape[0] - 1
@@ -240,7 +240,7 @@ class MetaModel(nn.Module):
             examples = examples[:, :pos+1]
             labels = labels[:, :pos+1]
 
-        output = self.llma(examples, images)
+        output = self.llma(examples, images, attention_mask=attention_mask)
         if isinstance(output, tuple):
             output, additional_loss = output
         else:

--- a/accessory/util/lr_sched.py
+++ b/accessory/util/lr_sched.py
@@ -1,16 +1,29 @@
 import math
 
 def adjust_learning_rate(optimizer, it, args):
-    """Decay the learning rate with half-cycle cosine after warmup"""
-    if it < args.warmup_iters: # 1) linear warmup for warmup_iters steps
-        lr = args.lr * it / args.warmup_iters
-    elif it > args.lr_decay_iters: # 2) if it > lr_decay_iters, return min learning rate
-        lr = args.min_lr
-    else: # 3) in between, use cosine decay down to min learning rate
-        decay_ratio = (it - args.warmup_iters) / (args.lr_decay_iters - args.warmup_iters)
-        assert 0 <= decay_ratio <= 1
-        coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))  # coeff ranges 0..1
-        lr = args.min_lr + (args.lr - args.min_lr) * coeff
+    """Adjust learning rate by configured schedule type."""
+    warmup_iters = max(int(getattr(args, "warmup_iters", 0)), 0)
+    schedule = getattr(args, "lr_schedule", "cosine")
+
+    if schedule == "constant":
+        if warmup_iters > 0 and it < warmup_iters:
+            lr = args.lr * it / warmup_iters
+        else:
+            lr = args.lr
+    elif schedule == "cosine":
+        if warmup_iters > 0 and it < warmup_iters:
+            lr = args.lr * it / warmup_iters
+        else:
+            lr_decay_iters = max(int(getattr(args, "lr_decay_iters", warmup_iters)), warmup_iters + 1)
+            if it > lr_decay_iters:
+                lr = args.min_lr
+            else:
+                decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+                decay_ratio = min(max(decay_ratio, 0.0), 1.0)
+                coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
+                lr = args.min_lr + (args.lr - args.min_lr) * coeff
+    else:
+        raise ValueError(f"Unsupported lr_schedule: {schedule}")
 
     for param_group in optimizer.param_groups:
         if "lr_scale" in param_group:

--- a/accessory/util/misc.py
+++ b/accessory/util/misc.py
@@ -512,6 +512,9 @@ def resume_stage2(args, model, optimizer, loss_scaler, dataset_train):
                 args.resume,
                 f"rank-specific-{dist.get_rank():05d}-of-{dist.get_world_size():05d}.pth",
             )
+            if getattr(args, "resume_reset_data_idx", False):
+                print("resume_reset_data_idx enabled: skip loading dataset state, data iteration restarts from beginning")
+                return
             try:
                 rank_specific_state_dict = torch.load(rank_specific_checkpoint_path)
                 dataset_train.load_state_dict(rank_specific_state_dict["dataset_state"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add pretrain args to control resume behavior:
  - `--resume_reset_data_idx`: skip loading dataset iterator state and restart data from beginning
  - `--resume_reset_lr`: keep global iteration/optimizer state but restart LR scheduler from step 0
  - `--lr_schedule`: explicit LR policy selection (`cosine` or `constant`)
- update pretrain loop to apply LR using a resume offset so LR can restart while iteration keeps increasing
- update resume logic to conditionally skip rank-specific dataset state restore
- harden LR scheduler handling with explicit schedule branching and safer warmup/decay edge handling
- add Megatron path-1 style packed-data controls:
  - `--reset_attention_mask`: build per-sample block-causal mask split by EOS boundaries
  - `--eod_mask_loss`: ignore EOS token loss by setting EOS labels to ignore index
- thread custom attention masks from training loop through `MetaModel` into LLaMA attention
- add compatibility guard in `MetaModel`: only forward `attention_mask` if current LLM `forward` supports this argument; otherwise raise a clear runtime error with guidance
- keep default behavior unchanged when the new switches are disabled

## Motivation
Support resumed training where model/optimizer/iteration continue from checkpoint, while data traversal and LR schedule can be restarted for a new data pass.
Also support Megatron-style packed-data boundary isolation and EOS loss masking without switching to TE/THD packed kernels.

## Testing
- syntax check with `python3 -m compileall` on modified python files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f5c17bd-8e0d-4360-9c0d-f7e81bf76c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f5c17bd-8e0d-4360-9c0d-f7e81bf76c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

